### PR TITLE
Add outcome-first Browser Clarity redesign proposal

### DIFF
--- a/DESIGN_PROPOSAL.md
+++ b/DESIGN_PROPOSAL.md
@@ -1,0 +1,144 @@
+# Browser Clarity — Data-Driven Sales Redesign
+
+## Goal
+Increase trial-to-paid conversion by making value obvious in the first 60 seconds and reducing feature overload in the primary interface.
+
+## What the current screen suggests
+From the screenshot, users are shown:
+- A dense navigation grid with many technical modules at once.
+- A large feed of low-severity events.
+- "Trial — 3 days remaining" shown, but weakly tied to outcomes or urgency.
+
+This likely creates **high cognitive load** and slows "aha" moments for security buyers.
+
+## Proposed new design: "Outcome-First Command Center"
+
+## 1) New top summary strip (replace part of icon density)
+Create a sticky KPI strip directly below the header:
+- **Risk Score** (overall)
+- **Critical Events Today**
+- **Trackers Blocked**
+- **Data Leak Attempts Prevented**
+- **Estimated Exposure Reduction**
+
+Each KPI card should include:
+- Big number
+- 7-day delta (+/- %)
+- Tiny sparkline
+- Click behavior to filtered evidence list
+
+Why it helps sales: decision makers buy outcomes, not features.
+
+## 2) Persona tabs to simplify first impression
+Replace the always-visible large module matrix with persona tabs:
+- **Executive View** (default)
+- **Security Ops**
+- **Privacy/Compliance**
+- **Developer**
+
+Default first view should open on Executive View with only 5–7 high-value actions and outcomes.
+
+Why it helps sales: less intimidation, faster relevance for non-technical buyers.
+
+## 3) "Proof of Value" panel above feed
+Add a right-side (or top) panel titled **"Proof of Value in this Session"**:
+- Leaks prevented: X
+- Trackers blocked: Y
+- Sensitive cookies protected: Z
+- Top blocked vendor categories
+- One-click export "Share with team"
+
+Also add a **"Generate ROI Report"** CTA for trial users.
+
+Why it helps sales: immediate evidence supports internal championing and procurement.
+
+## 4) Smarter event feed hierarchy
+Current feed appears dominated by low-level events. Redesign feed to:
+- Group similar events into collapsible bundles (e.g., "Cookies blocked (24)")
+- Show severe/high events first by default
+- Keep low severity in a muted collapsed section
+- Add "Explain impact" inline AI summary per event cluster
+
+Why it helps sales: highlights risk reduction, avoids noise fatigue.
+
+## 5) Trial conversion experience redesign
+Current trial badge is passive. Replace with active conversion components:
+- Countdown with milestone framing: "3 days left to export your first security baseline"
+- Checklist:
+  - Connect 3 key sites
+  - Run 1 full scan
+  - Export baseline report
+- Contextual upgrade nudges only after user reaches proof moments
+
+Why it helps sales: guided activation improves conversion probability.
+
+## 6) Navigation consolidation
+Reduce primary nav to 6 anchors:
+- Dashboard
+- Investigate
+- Protect
+- Reports
+- Integrations
+- Settings
+
+Move advanced modules into a secondary "Tools" drawer.
+
+Why it helps sales: cleaner IA improves trust and speed.
+
+## 7) Visual design update for premium perception
+Keep dark theme but improve commercial polish:
+- Increase spacing and reduce border clutter
+- Stronger contrast for core metrics
+- Fewer icon styles, consistent stroke weights
+- Accent color reserved for actionable value events and CTAs
+
+Why it helps sales: premium UX signals enterprise readiness.
+
+## Suggested primary layout (wireframe)
+1. Header (brand, account, environment, help)
+2. KPI strip (5 cards)
+3. Persona tabs
+4. Main content split:
+   - Left: prioritized insights + event clusters
+   - Right: proof-of-value + ROI/export panel
+5. Bottom utility bar (scan controls, ingestion status)
+
+## Messaging changes to improve conversion
+Replace technical labels with outcome language:
+- "Blocked: 384" -> "384 tracking attempts prevented"
+- "Risks" -> "Business risk detected"
+- "Perms" -> "Sensitive permission exposure"
+
+## Instrumentation plan (to validate redesign)
+Track these metrics before/after release:
+- Time to first "value event" (user sees meaningful prevention proof)
+- Trial users generating at least one report
+- Upgrade click-through rate by persona
+- 7-day retention in trial
+- Trial-to-paid conversion
+
+## A/B test ideas
+- **A:** Current feed-first UI
+- **B:** Outcome-first dashboard + proof panel
+- **C:** Outcome-first + guided checklist onboarding
+
+Success criteria:
+- +20% increase in report exports
+- +15% increase in upgrade intent clicks
+- +10% absolute lift in trial activation completion
+
+## Implementation phases
+1. Phase 1: KPI strip + proof panel + terminology refresh
+2. Phase 2: Persona tabs + feed clustering
+3. Phase 3: Guided trial checklist + ROI report generation
+4. Phase 4: Navigation consolidation + visual refinement
+
+## Fast win version (can ship quickly)
+If you need a rapid improvement:
+- Keep current layout mostly intact
+- Add KPI strip at top
+- Add proof-of-value panel above feed
+- Reorder feed by severity with grouping
+- Add one strong CTA: "Generate executive report"
+
+This can improve sales conversations without a full rebuild.


### PR DESCRIPTION
### Motivation
- Improve trial-to-paid conversion by making product value obvious within the first 60 seconds and reducing feature overload. 
- Change is driven by observations that the current UI is dense, feed-heavy, and shows trial status without clear, outcome-focused proof points. 

### Description
- Add a new design document at `DESIGN_PROPOSAL.md` that outlines an "Outcome-First Command Center" and a rollout plan. 
- Propose UI changes including a KPI summary strip, persona tabs (Executive, Security Ops, Privacy/Compliance, Developer), and a "Proof of Value" panel with one-click export and ROI CTA. 
- Recommend smarter event feed hierarchy with clustering and severity-first ordering, a guided trial conversion checklist, consolidated navigation, and visual polish for premium perception. 
- Include instrumentation and validation guidance with specific metrics, A/B test variants, phased implementation, and a fast-win path for rapid shipping. 

### Testing
- Confirmed the document was added and committed to branch `work` with `git` operations which completed successfully. 
- Verified file contents were printed with `nl -ba DESIGN_PROPOSAL.md | sed -n '1,220p'`, and there are no runtime code changes or automated unit tests required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e33497787483258ff43a04d4856fac)